### PR TITLE
Ajout navigation et base produits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# dependencies
+node_modules/
+
+# build output
+/dist
+
+# database
+products.db

--- a/package.json
+++ b/package.json
@@ -6,20 +6,24 @@
   "scripts": {
     "dev": "vite",
     "build": "npx vite build",
-    "serve": "vite preview"
+    "serve": "vite preview",
+    "start": "node server.js"
   },
   "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "framer-motion": "^11.0.0",
+    "lucide-react": "^0.321.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.23.0",
-    "lucide-react": "^0.321.0",
-    "framer-motion": "^11.0.0"
+    "sqlite3": "^5.1.6"
   },
   "devDependencies": {
+    "@vitejs/plugin-react": "^4.1.0",
     "autoprefixer": "^10.4.17",
     "postcss": "^8.4.33",
     "tailwindcss": "^3.4.1",
-    "vite": "^5.4.0",
-    "@vitejs/plugin-react": "^4.1.0"
+    "vite": "^5.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.23.0",
-    "sqlite3": "^5.1.6"
+    "sqlite3": "^5.1.6",
+    "sqlite": "^5.1.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.1.0",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,93 @@
+import express from 'express';
+import sqlite3 from 'sqlite3';
+import { open } from 'sqlite';
+import cors from 'cors';
+
+const dbPromise = open({ filename: './products.db', driver: sqlite3.Database });
+
+async function init() {
+  const db = await dbPromise;
+  await db.run(`CREATE TABLE IF NOT EXISTS products (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    price REAL,
+    image TEXT,
+    stock INTEGER,
+    category TEXT,
+    featured INTEGER DEFAULT 0
+  )`);
+  const count = await db.get('SELECT COUNT(*) as c FROM products');
+  if (count.c === 0) {
+    const sample = [
+      ['Booster Édition Spéciale', 9.9, '/featured/item1.jpg', 50, 'cartes', 1],
+      ['Carte Holo Rare', 14.5, '/featured/item2.jpg', 25, 'cartes', 1],
+      ['Display scellé', 120, '/featured/item3.jpg', 10, 'boites', 1]
+    ];
+    for (const p of sample) {
+      await db.run(
+        'INSERT INTO products (name, price, image, stock, category, featured) VALUES (?, ?, ?, ?, ?, ?)',
+        ...p
+      );
+    }
+  }
+}
+init();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.get('/api/products', async (req, res) => {
+  const { search, category, featured } = req.query;
+  let query = 'SELECT * FROM products';
+  const params = [];
+  const conditions = [];
+  if (search) {
+    conditions.push('name LIKE ?');
+    params.push(`%${search}%`);
+  }
+  if (category) {
+    conditions.push('category = ?');
+    params.push(category);
+  }
+  if (featured === '1') {
+    conditions.push('featured = 1');
+  }
+  if (conditions.length) {
+    query += ' WHERE ' + conditions.join(' AND ');
+  }
+  const products = await (await dbPromise).all(query, params);
+  res.json(products);
+});
+
+app.post('/api/products', async (req, res) => {
+  const { id, name, price, image, stock, category, featured } = req.body;
+  const db = await dbPromise;
+  if (id) {
+    await db.run(
+      `UPDATE products SET name=?, price=?, image=?, stock=?, category=?, featured=? WHERE id=?`,
+      name,
+      price,
+      image,
+      stock,
+      category,
+      featured ? 1 : 0,
+      id
+    );
+  } else {
+    await db.run(
+      `INSERT INTO products (name, price, image, stock, category, featured) VALUES (?, ?, ?, ?, ?, ?)`,
+      name,
+      price,
+      image,
+      stock,
+      category,
+      featured ? 1 : 0
+    );
+  }
+  const products = await db.all('SELECT * FROM products');
+  res.json(products);
+});
+
+const port = 3001;
+app.listen(port, () => console.log(`Server started on port ${port}`));

--- a/src/AdminPage.jsx
+++ b/src/AdminPage.jsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from "react";
+import Navbar from "./components/Navbar";
 
 export default function AdminPage() {
   const [products, setProducts] = useState([]);
   const [editing, setEditing] = useState(null);
-  const [form, setForm] = useState({ name: "", price: "", image: "", stock: "" });
+  const [form, setForm] = useState({ name: "", price: "", image: "", stock: "", category: "", featured: false });
 
   useEffect(() => {
     fetch("http://localhost:3001/api/products")
@@ -17,9 +18,14 @@ export default function AdminPage() {
     fetch("http://localhost:3001/api/products", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ...payload, price: parseFloat(payload.price), stock: parseInt(payload.stock) }),
+      body: JSON.stringify({
+        ...payload,
+        price: parseFloat(payload.price),
+        stock: parseInt(payload.stock),
+        featured: payload.featured,
+      }),
     }).then(() => {
-      setForm({ name: "", price: "", image: "", stock: "" });
+      setForm({ name: "", price: "", image: "", stock: "", category: "", featured: false });
       setEditing(null);
       fetch("http://localhost:3001/api/products")
         .then((res) => res.json())
@@ -34,12 +40,18 @@ export default function AdminPage() {
 
   return (
     <div className="p-4 max-w-3xl mx-auto">
+      <Navbar />
       <h1 className="text-2xl font-bold mb-4">Admin - Gestion des Produits</h1>
       <form onSubmit={handleSubmit} className="grid gap-2 mb-4">
         <input placeholder="Nom" value={form.name} onChange={e => setForm({ ...form, name: e.target.value })} />
         <input placeholder="Prix" value={form.price} onChange={e => setForm({ ...form, price: e.target.value })} />
         <input placeholder="Image URL" value={form.image} onChange={e => setForm({ ...form, image: e.target.value })} />
         <input placeholder="Stock" value={form.stock} onChange={e => setForm({ ...form, stock: e.target.value })} />
+        <input placeholder="Catégorie" value={form.category} onChange={e => setForm({ ...form, category: e.target.value })} />
+        <label className="flex items-center space-x-2">
+          <input type="checkbox" checked={form.featured} onChange={e => setForm({ ...form, featured: e.target.checked })} />
+          <span>Mettre en avant</span>
+        </label>
         <button type="submit" className="bg-green-600 text-white p-2 rounded">{editing ? "Modifier" : "Ajouter"}</button>
       </form>
       <ul>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,18 +1,18 @@
-import React from "react";
-import { Link } from "react-router-dom";
-import logo from "./assets/logo.png";
+import React, { useEffect, useState } from "react";
+import Navbar from "./components/Navbar";
 
 export default function App() {
+  const [featured, setFeatured] = useState([]);
+
+  useEffect(() => {
+    fetch("http://localhost:3001/api/products?featured=1")
+      .then((res) => res.json())
+      .then((data) => setFeatured(data));
+  }, []);
+
   return (
     <div className="min-h-screen bg-white flex flex-col items-center text-center">
-      <header className="w-full flex justify-between items-center px-6 py-4">
-        <img src={logo} alt="Nextwave Logo" className="h-12" />
-        <Link to="/boutique">
-          <button className="px-4 py-2 bg-blue-600 text-white rounded shadow hover:bg-blue-700">
-            Accéder à la boutique
-          </button>
-        </Link>
-      </header>
+      <Navbar />
 
       <main className="flex flex-col items-center p-6">
         <h1 className="text-4xl font-bold mb-4">Bienvenue sur Nextwave</h1>
@@ -21,18 +21,12 @@ export default function App() {
         </p>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-5xl w-full mb-12">
-          <div className="border rounded p-4 shadow">
-            <img src="/featured/item1.jpg" alt="Produit 1" className="w-full h-48 object-contain mb-2" />
-            <h2 className="font-semibold">Booster Édition Spéciale</h2>
-          </div>
-          <div className="border rounded p-4 shadow">
-            <img src="/featured/item2.jpg" alt="Produit 2" className="w-full h-48 object-contain mb-2" />
-            <h2 className="font-semibold">Carte Holo Rare</h2>
-          </div>
-          <div className="border rounded p-4 shadow">
-            <img src="/featured/item3.jpg" alt="Produit 3" className="w-full h-48 object-contain mb-2" />
-            <h2 className="font-semibold">Display scellé</h2>
-          </div>
+          {featured.map((p) => (
+            <div key={p.id} className="border rounded p-4 shadow">
+              <img src={p.image} alt={p.name} className="w-full h-48 object-contain mb-2" />
+              <h2 className="font-semibold">{p.name}</h2>
+            </div>
+          ))}
         </div>
       </main>
     </div>

--- a/src/LoginPage.jsx
+++ b/src/LoginPage.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import logo from "./assets/logo.png";
+import Navbar from "./components/Navbar";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
@@ -19,7 +19,7 @@ export default function LoginPage() {
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-gray-100 p-4">
-      <img src={logo} alt="Logo" className="h-16 mb-6" />
+      <Navbar />
       <form
         onSubmit={handleSubmit}
         className="bg-white p-6 rounded shadow-md w-full max-w-sm space-y-4"

--- a/src/ShopPage.jsx
+++ b/src/ShopPage.jsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
-import logo from "./assets/logo.png";
+import Navbar from "./components/Navbar";
 
 export default function ShopPage() {
   const [products, setProducts] = useState([]);
+  const [search, setSearch] = useState("");
+  const [category, setCategory] = useState("");
 
   useEffect(() => {
     fetch("http://localhost:3001/api/products")
@@ -11,17 +12,40 @@ export default function ShopPage() {
       .then((data) => setProducts(data));
   }, []);
 
+  const categories = [...new Set(products.map((p) => p.category).filter(Boolean))];
+  const filtered = products.filter(
+    (p) =>
+      p.name.toLowerCase().includes(search.toLowerCase()) &&
+      (!category || p.category === category)
+  );
+
   return (
     <div className="p-4">
-      <header className="flex justify-between items-center mb-6">
-        <img src={logo} alt="Nextwave Logo" className="h-12" />
-        <Link to="/login">
-          <button className="bg-blue-600 text-white px-4 py-2 rounded">Se connecter</button>
-        </Link>
-      </header>
+      <Navbar />
       <h1 className="text-2xl font-bold mb-4">Boutique</h1>
+      <div className="flex space-x-4 mb-4">
+        <input
+          type="text"
+          placeholder="Recherche"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="border px-2 py-1 rounded"
+        />
+        <select
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          className="border px-2 py-1 rounded"
+        >
+          <option value="">Toutes catégories</option>
+          {categories.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+      </div>
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-        {products.map((product) => (
+        {filtered.map((product) => (
           <div key={product.id} className="border p-2 rounded shadow-sm">
             <img src={product.image} alt={product.name} className="w-full h-40 object-contain mb-2" />
             <h2 className="font-bold">{product.name}</h2>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import logo from '../assets/logo.png';
+
+export default function Navbar() {
+  return (
+    <nav className="w-full flex items-center justify-between p-4 bg-gray-100 mb-4">
+      <div className="flex items-center space-x-4">
+        <img src={logo} alt="Nextwave Logo" className="h-10" />
+        <Link to="/" className="font-semibold">Accueil</Link>
+        <Link to="/boutique" className="font-semibold">Boutique</Link>
+      </div>
+      <Link to="/login" className="text-blue-600">Admin</Link>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- add an Express/SQLite backend with products API
- seed sample products
- create a reusable Navbar component
- show navbar on all pages
- display featured items on home page
- add filters to the shop page
- extend admin page to manage category and featured

## Testing
- `npm run build` *(fails: requires installing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68418515108c83298540ccda1cd65309