### PR TITLE
Add cart sidebar and update styles

### DIFF
--- a/server.js
+++ b/server.js
@@ -19,9 +19,11 @@ async function init() {
   const count = await db.get('SELECT COUNT(*) as c FROM products');
   if (count.c === 0) {
     const sample = [
-      ['Booster Édition Spéciale', 9.9, '/featured/item1.jpg', 50, 'cartes', 1],
-      ['Carte Holo Rare', 14.5, '/featured/item2.jpg', 25, 'cartes', 1],
-      ['Display scellé', 120, '/featured/item3.jpg', 10, 'boites', 1]
+      ['Booster Édition Spéciale', 9.9, 'https://via.placeholder.com/300x200?text=Item1', 50, 'cartes', 1],
+      ['Carte Holo Rare', 14.5, 'https://via.placeholder.com/300x200?text=Item2', 25, 'cartes', 1],
+      ['Display scellé', 120, 'https://via.placeholder.com/300x200?text=Item3', 10, 'boites', 1],
+      ['Jeu de cartes collector', 19.9, 'https://via.placeholder.com/300x200?text=Item4', 40, 'cartes', 0],
+      ['Poster exclusif', 7.5, 'https://via.placeholder.com/300x200?text=Item5', 60, 'goodies', 0]
     ];
     for (const p of sample) {
       await db.run(

--- a/src/AdminPage.jsx
+++ b/src/AdminPage.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import Navbar from "./components/Navbar";
+import CartSidebar from "./components/CartSidebar";
 
 export default function AdminPage() {
   const [products, setProducts] = useState([]);
@@ -39,8 +40,9 @@ export default function AdminPage() {
   };
 
   return (
-    <div className="p-4 max-w-3xl mx-auto">
+    <div className="p-4 max-w-3xl mx-auto min-h-screen bg-gray-100">
       <Navbar />
+      <CartSidebar />
       <h1 className="text-2xl font-bold mb-4">Admin - Gestion des Produits</h1>
       <form onSubmit={handleSubmit} className="grid gap-2 mb-4">
         <input placeholder="Nom" value={form.name} onChange={e => setForm({ ...form, name: e.target.value })} />
@@ -54,14 +56,32 @@ export default function AdminPage() {
         </label>
         <button type="submit" className="bg-green-600 text-white p-2 rounded">{editing ? "Modifier" : "Ajouter"}</button>
       </form>
-      <ul>
-        {products.map(p => (
-          <li key={p.id} className="mb-2">
-            {p.name} - {p.price}€ - Stock: {p.stock}
-            <button className="ml-2 text-blue-500" onClick={() => handleEdit(p)}>Modifier</button>
-          </li>
-        ))}
-      </ul>
+      <table className="w-full text-left border-collapse">
+        <thead>
+          <tr>
+            <th className="border p-2">Nom</th>
+            <th className="border p-2">Prix</th>
+            <th className="border p-2">Stock</th>
+            <th className="border p-2">Catégorie</th>
+            <th className="border p-2">Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {products.map((p) => (
+            <tr key={p.id}>
+              <td className="border p-2">{p.name}</td>
+              <td className="border p-2">{p.price}</td>
+              <td className="border p-2">{p.stock}</td>
+              <td className="border p-2">{p.category}</td>
+              <td className="border p-2">
+                <button className="text-blue-500" onClick={() => handleEdit(p)}>
+                  Modifier
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import Navbar from "./components/Navbar";
+import CartSidebar from "./components/CartSidebar";
 
 export default function App() {
   const [featured, setFeatured] = useState([]);
@@ -11,8 +12,9 @@ export default function App() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-white flex flex-col items-center text-center">
+    <div className="min-h-screen bg-gray-100 flex flex-col items-center text-center">
       <Navbar />
+      <CartSidebar />
 
       <main className="flex flex-col items-center p-6">
         <h1 className="text-4xl font-bold mb-4">Bienvenue sur Nextwave</h1>

--- a/src/LoginPage.jsx
+++ b/src/LoginPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Navbar from "./components/Navbar";
+import CartSidebar from "./components/CartSidebar";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
@@ -20,6 +21,7 @@ export default function LoginPage() {
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-gray-100 p-4">
       <Navbar />
+      <CartSidebar />
       <form
         onSubmit={handleSubmit}
         className="bg-white p-6 rounded shadow-md w-full max-w-sm space-y-4"

--- a/src/ShopPage.jsx
+++ b/src/ShopPage.jsx
@@ -1,10 +1,13 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useContext } from "react";
 import Navbar from "./components/Navbar";
+import CartSidebar from "./components/CartSidebar";
+import { CartContext } from "./context/CartContext";
 
 export default function ShopPage() {
   const [products, setProducts] = useState([]);
   const [search, setSearch] = useState("");
   const [category, setCategory] = useState("");
+  const { addItem } = useContext(CartContext);
 
   useEffect(() => {
     fetch("http://localhost:3001/api/products")
@@ -20,8 +23,9 @@ export default function ShopPage() {
   );
 
   return (
-    <div className="p-4">
+    <div className="p-4 min-h-screen bg-gray-100">
       <Navbar />
+      <CartSidebar />
       <h1 className="text-2xl font-bold mb-4">Boutique</h1>
       <div className="flex space-x-4 mb-4">
         <input
@@ -51,6 +55,12 @@ export default function ShopPage() {
             <h2 className="font-bold">{product.name}</h2>
             <p>{product.price.toFixed(2)} €</p>
             <p className="text-sm text-gray-600">Stock : {product.stock}</p>
+            <button
+              className="mt-2 bg-blue-600 text-white px-2 py-1 rounded"
+              onClick={() => addItem(product)}
+            >
+              Ajouter
+            </button>
           </div>
         ))}
       </div>

--- a/src/components/CartSidebar.jsx
+++ b/src/components/CartSidebar.jsx
@@ -1,0 +1,24 @@
+import React, { useContext } from 'react';
+import { CartContext } from '../context/CartContext';
+
+export default function CartSidebar() {
+  const { items } = useContext(CartContext);
+
+  return (
+    <aside className="fixed right-0 top-0 w-64 h-full bg-white shadow-lg p-4 overflow-y-auto">
+      <h2 className="text-lg font-bold mb-4">Panier</h2>
+      {items.length === 0 ? (
+        <p className="text-sm text-gray-500">Votre panier est vide.</p>
+      ) : (
+        <ul className="space-y-2">
+          {items.map((item, idx) => (
+            <li key={idx} className="flex justify-between">
+              <span>{item.name}</span>
+              <span>{item.price.toFixed(2)} €</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </aside>
+  );
+}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -4,7 +4,7 @@ import logo from '../assets/logo.png';
 
 export default function Navbar() {
   return (
-    <nav className="w-full flex items-center justify-between p-4 bg-gray-100 mb-4">
+    <nav className="w-full flex items-center justify-between p-4 bg-white mb-4 shadow">
       <div className="flex items-center space-x-4">
         <img src={logo} alt="Nextwave Logo" className="h-10" />
         <Link to="/" className="font-semibold">Accueil</Link>

--- a/src/context/CartContext.jsx
+++ b/src/context/CartContext.jsx
@@ -1,0 +1,16 @@
+import React, { createContext, useState } from 'react';
+
+export const CartContext = createContext();
+
+export function CartProvider({ children }) {
+  const [items, setItems] = useState([]);
+
+  const addItem = (product) => setItems((prev) => [...prev, product]);
+  const removeItem = (id) => setItems((prev) => prev.filter((p) => p.id !== id));
+
+  return (
+    <CartContext.Provider value={{ items, addItem, removeItem }}>
+      {children}
+    </CartContext.Provider>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,17 +5,20 @@ import App from "./App";
 import ShopPage from "./ShopPage";
 import AdminPage from "./AdminPage";
 import LoginPage from "./LoginPage";
+import { CartProvider } from "./context/CartContext";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <Router>
-      <Routes>
-        <Route path="/" element={<App />} />
-        <Route path="/boutique" element={<ShopPage />} />
-        <Route path="/admin" element={<AdminPage />} />
-        <Route path="/login" element={<LoginPage />} />
-      </Routes>
-    </Router>
+    <CartProvider>
+      <Router>
+        <Routes>
+          <Route path="/" element={<App />} />
+          <Route path="/boutique" element={<ShopPage />} />
+          <Route path="/admin" element={<AdminPage />} />
+          <Route path="/login" element={<LoginPage />} />
+        </Routes>
+      </Router>
+    </CartProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- swap navbar and page colors
- introduce cart sidebar using a CartContext
- showcase three featured products and five total sample items
- allow editing products from an improved admin table

## Testing
- `npm run build` *(fails: requires online package install)*

------
https://chatgpt.com/codex/tasks/task_e_68418e1aedd08329add4104d98ee24ae