### PR TITLE
Improve cart sidebar and navbar alignment

### DIFF
--- a/src/ShopPage.jsx
+++ b/src/ShopPage.jsx
@@ -23,11 +23,12 @@ export default function ShopPage() {
   );
 
   return (
-    <div className="p-4 min-h-screen bg-gray-100">
+    <div className="min-h-screen bg-gray-100">
       <Navbar />
       <CartSidebar />
-      <h1 className="text-2xl font-bold mb-4">Boutique</h1>
-      <div className="flex space-x-4 mb-4">
+      <div className="p-4">
+        <h1 className="text-2xl font-bold mb-4">Boutique</h1>
+        <div className="flex space-x-4 mb-4">
         <input
           type="text"
           placeholder="Recherche"
@@ -63,6 +64,7 @@ export default function ShopPage() {
             </button>
           </div>
         ))}
+      </div>
       </div>
     </div>
   );

--- a/src/components/CartSidebar.jsx
+++ b/src/components/CartSidebar.jsx
@@ -2,10 +2,12 @@ import React, { useContext } from 'react';
 import { CartContext } from '../context/CartContext';
 
 export default function CartSidebar() {
-  const { items } = useContext(CartContext);
+  const { items, open } = useContext(CartContext);
 
   return (
-    <aside className="fixed right-0 top-0 w-64 h-full bg-white shadow-lg p-4 overflow-y-auto">
+    <aside
+      className={`fixed right-0 top-0 w-64 h-full bg-white shadow-lg p-4 overflow-y-auto transform transition-transform ${open ? 'translate-x-0' : 'translate-x-full'}`}
+    >
       <h2 className="text-lg font-bold mb-4">Panier</h2>
       {items.length === 0 ? (
         <p className="text-sm text-gray-500">Votre panier est vide.</p>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,11 +1,29 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import logo from '../assets/logo.png';
+import { CartContext } from '../context/CartContext';
 
 export default function Navbar() {
+  const { toggleCart } = useContext(CartContext);
+
   return (
     <nav className="w-full flex items-center justify-between p-4 bg-white mb-4 shadow">
       <div className="flex items-center space-x-4">
+        <button
+          onClick={toggleCart}
+          className="md:hidden p-2 focus:outline-none"
+          aria-label="Toggle cart"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-6 w-6"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
         <img src={logo} alt="Nextwave Logo" className="h-10" />
         <Link to="/" className="font-semibold">Accueil</Link>
         <Link to="/boutique" className="font-semibold">Boutique</Link>

--- a/src/context/CartContext.jsx
+++ b/src/context/CartContext.jsx
@@ -4,12 +4,14 @@ export const CartContext = createContext();
 
 export function CartProvider({ children }) {
   const [items, setItems] = useState([]);
+  const [open, setOpen] = useState(false);
 
   const addItem = (product) => setItems((prev) => [...prev, product]);
   const removeItem = (id) => setItems((prev) => prev.filter((p) => p.id !== id));
+  const toggleCart = () => setOpen((o) => !o);
 
   return (
-    <CartContext.Provider value={{ items, addItem, removeItem }}>
+    <CartContext.Provider value={{ items, addItem, removeItem, open, toggleCart }}>
       {children}
     </CartContext.Provider>
   );


### PR DESCRIPTION
## Summary
- allow cart sidebar to be toggled via context
- slide cart sidebar in and out of view
- add burger button in the navbar
- align the shop page navbar with the screen top

## Testing
- `npm run build` *(fails: Need to install vite)*

------
https://chatgpt.com/codex/tasks/task_e_68419112f61c8329b283cb17ef6c8617