### PR TITLE
Add SQLite product database

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Nextwave Site
+
+This project uses an Express server with a SQLite database to store product information. The database is automatically created and populated with demo products when the server starts.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the server and front-end in two separate terminals:
+   ```bash
+   npm start       # starts the API server on port 3001
+   npm run dev     # starts the Vite dev server for the React app
+   ```
+
+The React app fetches products from `http://localhost:3001/api/products`.

--- a/db.js
+++ b/db.js
@@ -1,0 +1,34 @@
+import sqlite3 from 'sqlite3';
+import { open } from 'sqlite';
+
+export const dbPromise = open({ filename: './products.db', driver: sqlite3.Database });
+
+export async function initDb() {
+  const db = await dbPromise;
+  await db.run(`CREATE TABLE IF NOT EXISTS products (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    price REAL,
+    image TEXT,
+    stock INTEGER,
+    category TEXT,
+    featured INTEGER DEFAULT 0
+  )`);
+
+  const count = await db.get('SELECT COUNT(*) as c FROM products');
+  if (count.c === 0) {
+    const sample = [
+      ['Booster Édition Spéciale', 9.9, 'https://via.placeholder.com/300x200?text=Item1', 50, 'cartes', 1],
+      ['Carte Holo Rare', 14.5, 'https://via.placeholder.com/300x200?text=Item2', 25, 'cartes', 1],
+      ['Display scellé', 120, 'https://via.placeholder.com/300x200?text=Item3', 10, 'boites', 1],
+      ['Jeu de cartes collector', 19.9, 'https://via.placeholder.com/300x200?text=Item4', 40, 'cartes', 0],
+      ['Poster exclusif', 7.5, 'https://via.placeholder.com/300x200?text=Item5', 60, 'goodies', 0]
+    ];
+    for (const p of sample) {
+      await db.run(
+        'INSERT INTO products (name, price, image, stock, category, featured) VALUES (?, ?, ?, ?, ?, ?)',
+        ...p
+      );
+    }
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,39 +1,9 @@
 import express from 'express';
-import sqlite3 from 'sqlite3';
-import { open } from 'sqlite';
 import cors from 'cors';
+import { dbPromise, initDb } from './db.js';
 
-const dbPromise = open({ filename: './products.db', driver: sqlite3.Database });
-
-async function init() {
-  const db = await dbPromise;
-  await db.run(`CREATE TABLE IF NOT EXISTS products (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    name TEXT,
-    price REAL,
-    image TEXT,
-    stock INTEGER,
-    category TEXT,
-    featured INTEGER DEFAULT 0
-  )`);
-  const count = await db.get('SELECT COUNT(*) as c FROM products');
-  if (count.c === 0) {
-    const sample = [
-      ['Booster Édition Spéciale', 9.9, 'https://via.placeholder.com/300x200?text=Item1', 50, 'cartes', 1],
-      ['Carte Holo Rare', 14.5, 'https://via.placeholder.com/300x200?text=Item2', 25, 'cartes', 1],
-      ['Display scellé', 120, 'https://via.placeholder.com/300x200?text=Item3', 10, 'boites', 1],
-      ['Jeu de cartes collector', 19.9, 'https://via.placeholder.com/300x200?text=Item4', 40, 'cartes', 0],
-      ['Poster exclusif', 7.5, 'https://via.placeholder.com/300x200?text=Item5', 60, 'goodies', 0]
-    ];
-    for (const p of sample) {
-      await db.run(
-        'INSERT INTO products (name, price, image, stock, category, featured) VALUES (?, ?, ?, ?, ?, ?)',
-        ...p
-      );
-    }
-  }
-}
-init();
+// Initialize the SQLite database and seed demo data on start
+initDb();
 
 const app = express();
 app.use(cors());


### PR DESCRIPTION
## Summary
- set up SQLite database initialization in `db.js`
- hook Express server into the new database
- document setup in a new `README`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68419e4814f48329b8e1448957eca4c2