### PR TITLE
Add sliding cart sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Nextwave Site
+
+This project uses an Express server with a SQLite database to store product information. The database is automatically created and populated with demo products when the server starts.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the server and front-end in two separate terminals:
+   ```bash
+   npm start       # starts the API server on port 3001
+   npm run dev     # starts the Vite dev server for the React app
+   ```
+
+The React app fetches products from `http://localhost:3001/api/products`.

--- a/db.js
+++ b/db.js
@@ -1,0 +1,34 @@
+import sqlite3 from 'sqlite3';
+import { open } from 'sqlite';
+
+export const dbPromise = open({ filename: './products.db', driver: sqlite3.Database });
+
+export async function initDb() {
+  const db = await dbPromise;
+  await db.run(`CREATE TABLE IF NOT EXISTS products (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    price REAL,
+    image TEXT,
+    stock INTEGER,
+    category TEXT,
+    featured INTEGER DEFAULT 0
+  )`);
+
+  const count = await db.get('SELECT COUNT(*) as c FROM products');
+  if (count.c === 0) {
+    const sample = [
+      ['Booster Édition Spéciale', 9.9, 'https://via.placeholder.com/300x200?text=Item1', 50, 'cartes', 1],
+      ['Carte Holo Rare', 14.5, 'https://via.placeholder.com/300x200?text=Item2', 25, 'cartes', 1],
+      ['Display scellé', 120, 'https://via.placeholder.com/300x200?text=Item3', 10, 'boites', 1],
+      ['Jeu de cartes collector', 19.9, 'https://via.placeholder.com/300x200?text=Item4', 40, 'cartes', 0],
+      ['Poster exclusif', 7.5, 'https://via.placeholder.com/300x200?text=Item5', 60, 'goodies', 0]
+    ];
+    for (const p of sample) {
+      await db.run(
+        'INSERT INTO products (name, price, image, stock, category, featured) VALUES (?, ?, ?, ?, ?, ?)',
+        ...p
+      );
+    }
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,39 +1,9 @@
 import express from 'express';
-import sqlite3 from 'sqlite3';
-import { open } from 'sqlite';
 import cors from 'cors';
+import { dbPromise, initDb } from './db.js';
 
-const dbPromise = open({ filename: './products.db', driver: sqlite3.Database });
-
-async function init() {
-  const db = await dbPromise;
-  await db.run(`CREATE TABLE IF NOT EXISTS products (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    name TEXT,
-    price REAL,
-    image TEXT,
-    stock INTEGER,
-    category TEXT,
-    featured INTEGER DEFAULT 0
-  )`);
-  const count = await db.get('SELECT COUNT(*) as c FROM products');
-  if (count.c === 0) {
-    const sample = [
-      ['Booster Édition Spéciale', 9.9, 'https://via.placeholder.com/300x200?text=Item1', 50, 'cartes', 1],
-      ['Carte Holo Rare', 14.5, 'https://via.placeholder.com/300x200?text=Item2', 25, 'cartes', 1],
-      ['Display scellé', 120, 'https://via.placeholder.com/300x200?text=Item3', 10, 'boites', 1],
-      ['Jeu de cartes collector', 19.9, 'https://via.placeholder.com/300x200?text=Item4', 40, 'cartes', 0],
-      ['Poster exclusif', 7.5, 'https://via.placeholder.com/300x200?text=Item5', 60, 'goodies', 0]
-    ];
-    for (const p of sample) {
-      await db.run(
-        'INSERT INTO products (name, price, image, stock, category, featured) VALUES (?, ?, ?, ?, ?, ?)',
-        ...p
-      );
-    }
-  }
-}
-init();
+// Initialize the SQLite database and seed demo data on start
+initDb();
 
 const app = express();
 app.use(cors());

--- a/src/components/CartSidebar.jsx
+++ b/src/components/CartSidebar.jsx
@@ -2,25 +2,41 @@ import React, { useContext } from 'react';
 import { CartContext } from '../context/CartContext';
 
 export default function CartSidebar() {
-  const { items, open } = useContext(CartContext);
+  const { items, open, toggleCart } = useContext(CartContext);
 
   return (
-    <aside
-      className={`fixed right-0 top-0 w-64 h-full bg-white shadow-lg p-4 overflow-y-auto transform transition-transform ${open ? 'translate-x-0' : 'translate-x-full'}`}
-    >
-      <h2 className="text-lg font-bold mb-4">Panier</h2>
-      {items.length === 0 ? (
-        <p className="text-sm text-gray-500">Votre panier est vide.</p>
-      ) : (
-        <ul className="space-y-2">
-          {items.map((item, idx) => (
-            <li key={idx} className="flex justify-between">
-              <span>{item.name}</span>
-              <span>{item.price.toFixed(2)} €</span>
-            </li>
-          ))}
-        </ul>
+    <>
+      {open && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-40 z-40"
+          onClick={toggleCart}
+          aria-hidden="true"
+        ></div>
       )}
-    </aside>
+      <aside
+        className={`fixed right-0 top-0 w-64 h-full bg-white shadow-lg p-4 overflow-y-auto transform transition-transform z-50 ${open ? 'translate-x-0' : 'translate-x-full'}`}
+      >
+        <button
+          className="absolute top-2 left-2 text-gray-600"
+          onClick={toggleCart}
+          aria-label="Fermer le panier"
+        >
+          &times;
+        </button>
+        <h2 className="text-lg font-bold mb-4 mt-6">Panier</h2>
+        {items.length === 0 ? (
+          <p className="text-sm text-gray-500">Votre panier est vide.</p>
+        ) : (
+          <ul className="space-y-2">
+            {items.map((item, idx) => (
+              <li key={idx} className="flex justify-between">
+                <span>{item.name}</span>
+                <span>{item.price.toFixed(2)} €</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </aside>
+    </>
   );
 }

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -4,31 +4,39 @@ import logo from '../assets/logo.png';
 import { CartContext } from '../context/CartContext';
 
 export default function Navbar() {
-  const { toggleCart } = useContext(CartContext);
+  const { toggleCart, items } = useContext(CartContext);
 
   return (
     <nav className="w-full flex items-center justify-between p-4 bg-white mb-4 shadow">
       <div className="flex items-center space-x-4">
-        <button
-          onClick={toggleCart}
-          className="md:hidden p-2 focus:outline-none"
-          aria-label="Toggle cart"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            className="h-6 w-6"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-          </svg>
-        </button>
         <img src={logo} alt="Nextwave Logo" className="h-10" />
         <Link to="/" className="font-semibold">Accueil</Link>
         <Link to="/boutique" className="font-semibold">Boutique</Link>
       </div>
-      <Link to="/login" className="text-blue-600">Admin</Link>
+      <div className="flex items-center space-x-4">
+        <button
+          onClick={toggleCart}
+          className="relative p-2 focus:outline-none"
+          aria-label="Voir le panier"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            className="h-6 w-6"
+          >
+            <path d="M3 3h2l.4 2M7 13h10l4-8H5.4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+            <circle cx="9" cy="21" r="1" />
+            <circle cx="20" cy="21" r="1" />
+          </svg>
+          {items.length > 0 && (
+            <span className="absolute -top-1 -right-1 bg-red-600 text-white text-xs rounded-full w-5 h-5 flex items-center justify-center">
+              {items.length}
+            </span>
+          )}
+        </button>
+        <Link to="/login" className="text-blue-600">Admin</Link>
+      </div>
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- display cart toggle button in `Navbar` with item count
- slide out cart sidebar with overlay and close button

## Testing
- `npm run build` *(fails: Error: canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68419e4814f48329b8e1448957eca4c2