### PR TITLE
Add stock control on admin page

### DIFF
--- a/src/AdminPage.jsx
+++ b/src/AdminPage.jsx
@@ -39,6 +39,21 @@ export default function AdminPage() {
     setEditing(product.id);
   };
 
+  const handleStockChange = (id, delta) => {
+    const product = products.find((p) => p.id === id);
+    if (!product) return;
+    const newStock = Math.max(0, product.stock + delta);
+    fetch("http://localhost:3001/api/products", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...product, stock: newStock }),
+    }).then(() => {
+      fetch("http://localhost:3001/api/products")
+        .then((res) => res.json())
+        .then((data) => setProducts(data));
+    });
+  };
+
   return (
     <div className="p-4 max-w-3xl mx-auto min-h-screen bg-gray-100">
       <Navbar />
@@ -76,7 +91,25 @@ export default function AdminPage() {
             <tr key={p.id}>
               <td className="border p-2">{p.name}</td>
               <td className="border p-2">{p.price}</td>
-              <td className="border p-2">{p.stock}</td>
+              <td className="border p-2">
+                <div className="flex items-center space-x-2">
+                  <button
+                    type="button"
+                    className="px-2 py-1 bg-gray-200 rounded"
+                    onClick={() => handleStockChange(p.id, -1)}
+                  >
+                    -
+                  </button>
+                  <span>{p.stock}</span>
+                  <button
+                    type="button"
+                    className="px-2 py-1 bg-gray-200 rounded"
+                    onClick={() => handleStockChange(p.id, 1)}
+                  >
+                    +
+                  </button>
+                </div>
+              </td>
               <td className="border p-2">{p.category}</td>
               <td className="border p-2">
                 <button className="text-blue-500" onClick={() => handleEdit(p)}>


### PR DESCRIPTION
## Summary
- allow manual stock increment/decrement on the admin panel

## Testing
- `npm run build` *(fails: `npm ERR! canceled`)*

------
https://chatgpt.com/codex/tasks/task_e_6841c52c49988329a39d0146326c876d