### PR TITLE
Fix API URL handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,5 @@ This project uses an Express server with a SQLite database to store product info
    npm run dev     # starts the Vite dev server for the React app
    ```
 
-The React app fetches products from `http://82.67.146.55:3001/api/products`.
+The React app fetches products from `/api/products` which is proxied to
+`http://localhost:3001` when running in development.

--- a/src/AdminPage.jsx
+++ b/src/AdminPage.jsx
@@ -8,7 +8,7 @@ export default function AdminPage() {
   const [form, setForm] = useState({ name: "", price: "", image: "", stock: "", category: "", featured: false });
 
   useEffect(() => {
-    fetch("http://82.67.146.55:3001/api/products")
+    fetch("/api/products")
       .then((res) => res.json())
       .then((data) => setProducts(data));
   }, []);
@@ -16,7 +16,7 @@ export default function AdminPage() {
   const handleSubmit = (e) => {
     e.preventDefault();
     const payload = editing ? { ...form, id: editing } : form;
-    fetch("http://82.67.146.55:3001/api/products", {
+    fetch("/api/products", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -28,7 +28,7 @@ export default function AdminPage() {
     }).then(() => {
       setForm({ name: "", price: "", image: "", stock: "", category: "", featured: false });
       setEditing(null);
-      fetch("http://82.67.146.55:3001/api/products")
+      fetch("/api/products")
         .then((res) => res.json())
         .then((data) => setProducts(data));
     });
@@ -43,12 +43,12 @@ export default function AdminPage() {
     const product = products.find((p) => p.id === id);
     if (!product) return;
     const newStock = Math.max(0, product.stock + delta);
-    fetch("http://82.67.146.55:3001/api/products", {
+    fetch("/api/products", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ ...product, stock: newStock }),
     }).then(() => {
-      fetch("http://82.67.146.55:3001/api/products")
+      fetch("/api/products")
         .then((res) => res.json())
         .then((data) => setProducts(data));
     });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,7 +6,7 @@ export default function App() {
   const [featured, setFeatured] = useState([]);
 
   useEffect(() => {
-    fetch("http://82.67.146.55:3001/api/products?featured=1")
+    fetch("/api/products?featured=1")
       .then((res) => res.json())
       .then((data) => setFeatured(data));
   }, []);

--- a/src/ShopPage.jsx
+++ b/src/ShopPage.jsx
@@ -10,7 +10,7 @@ export default function ShopPage() {
   const { addItem } = useContext(CartContext);
 
   useEffect(() => {
-    fetch("http://82.67.146.55:3001/api/products")
+    fetch("/api/products")
       .then((res) => res.json())
       .then((data) => setProducts(data));
   }, []);

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,11 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3001'
+    }
+  },
   resolve: {
     alias: {
       '@': '/src'


### PR DESCRIPTION
## Summary
- use relative `/api` URLs instead of hard-coded IP addresses
- add dev-server proxy config in vite
- document the new API path

## Testing
- `npm run build` *(fails: needed package download requires network)*

------
https://chatgpt.com/codex/tasks/task_e_6841ec5670388329af46e43f5e5918a0