### PR TITLE
Add inventory history feature

### DIFF
--- a/db.js
+++ b/db.js
@@ -15,6 +15,16 @@ export async function initDb() {
     featured INTEGER DEFAULT 0
   )`);
 
+  await db.run(`CREATE TABLE IF NOT EXISTS history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    product_id INTEGER,
+    name TEXT,
+    action TEXT,
+    price REAL,
+    stock INTEGER,
+    date DATETIME DEFAULT CURRENT_TIMESTAMP
+  )`);
+
   const count = await db.get('SELECT COUNT(*) as c FROM products');
   if (count.c === 0) {
     const sample = [

--- a/server.js
+++ b/server.js
@@ -9,6 +9,12 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
+app.get('/api/history', async (req, res) => {
+  const db = await dbPromise;
+  const history = await db.all('SELECT * FROM history ORDER BY date DESC');
+  res.json(history);
+});
+
 app.get('/api/products', async (req, res) => {
   const { search, category, featured } = req.query;
   let query = 'SELECT * FROM products';
@@ -46,8 +52,15 @@ app.post('/api/products', async (req, res) => {
       featured ? 1 : 0,
       id
     );
-  } else {
     await db.run(
+      `INSERT INTO history (product_id, name, action, price, stock) VALUES (?, ?, 'update', ?, ?)`,
+      id,
+      name,
+      price,
+      stock
+    );
+  } else {
+    const result = await db.run(
       `INSERT INTO products (name, price, image, stock, category, featured) VALUES (?, ?, ?, ?, ?, ?)`,
       name,
       price,
@@ -55,6 +68,30 @@ app.post('/api/products', async (req, res) => {
       stock,
       category,
       featured ? 1 : 0
+    );
+    await db.run(
+      `INSERT INTO history (product_id, name, action, price, stock) VALUES (?, ?, 'add', ?, ?)`,
+      result.lastID,
+      name,
+      price,
+      stock
+    );
+  }
+  const products = await db.all('SELECT * FROM products');
+  res.json(products);
+});
+
+app.delete('/api/products/:id', async (req, res) => {
+  const db = await dbPromise;
+  const product = await db.get('SELECT * FROM products WHERE id=?', req.params.id);
+  await db.run('DELETE FROM products WHERE id=?', req.params.id);
+  if (product) {
+    await db.run(
+      `INSERT INTO history (product_id, name, action, price, stock) VALUES (?, ?, 'delete', ?, ?)`,
+      product.id,
+      product.name,
+      product.price,
+      product.stock
     );
   }
   const products = await db.all('SELECT * FROM products');

--- a/src/AdminPage.jsx
+++ b/src/AdminPage.jsx
@@ -54,11 +54,21 @@ export default function AdminPage() {
     });
   };
 
+  const handleDelete = (id) => {
+    if (!window.confirm("Supprimer ce produit ?")) return;
+    fetch(`/api/products/${id}`, { method: "DELETE" }).then(() => {
+      fetch("/api/products")
+        .then((res) => res.json())
+        .then((data) => setProducts(data));
+    });
+  };
+
   return (
     <div className="p-4 max-w-3xl mx-auto min-h-screen bg-gray-100">
       <Navbar />
       <CartSidebar />
       <h1 className="text-2xl font-bold mb-4">Admin - Gestion des Produits</h1>
+      <a href="/historique" className="text-blue-600 underline mb-4 inline-block">Voir l'historique</a>
       <form onSubmit={handleSubmit} className="grid gap-2 mb-4">
         <input placeholder="Nom" value={form.name} onChange={e => setForm({ ...form, name: e.target.value })} />
         <input placeholder="Prix" value={form.price} onChange={e => setForm({ ...form, price: e.target.value })} />
@@ -114,6 +124,12 @@ export default function AdminPage() {
               <td className="border p-2">
                 <button className="text-blue-500" onClick={() => handleEdit(p)}>
                   Modifier
+                </button>
+                <button
+                  className="ml-2 text-red-500"
+                  onClick={() => handleDelete(p.id)}
+                >
+                  Supprimer
                 </button>
               </td>
             </tr>

--- a/src/HistoryPage.jsx
+++ b/src/HistoryPage.jsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from "react";
+import Navbar from "./components/Navbar";
+import CartSidebar from "./components/CartSidebar";
+
+export default function HistoryPage() {
+  const [history, setHistory] = useState([]);
+
+  useEffect(() => {
+    fetch("/api/history")
+      .then((res) => res.json())
+      .then((data) => setHistory(data));
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gray-100 p-4">
+      <Navbar />
+      <CartSidebar />
+      <h1 className="text-2xl font-bold mb-4">Historique des Mouvements</h1>
+      <table className="w-full text-left border-collapse">
+        <thead>
+          <tr>
+            <th className="border p-2">Date</th>
+            <th className="border p-2">Produit</th>
+            <th className="border p-2">Action</th>
+            <th className="border p-2">Prix</th>
+            <th className="border p-2">Stock</th>
+          </tr>
+        </thead>
+        <tbody>
+          {history.map((h) => (
+            <tr key={h.id}>
+              <td className="border p-2">{new Date(h.date).toLocaleString()}</td>
+              <td className="border p-2">{h.name}</td>
+              <td className="border p-2">{h.action}</td>
+              <td className="border p-2">{h.price}</td>
+              <td className="border p-2">{h.stock}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,6 +5,7 @@ import App from "./App";
 import ShopPage from "./ShopPage";
 import AdminPage from "./AdminPage";
 import LoginPage from "./LoginPage";
+import HistoryPage from "./HistoryPage";
 import { CartProvider } from "./context/CartContext";
 import "./index.css";
 
@@ -16,6 +17,7 @@ ReactDOM.createRoot(document.getElementById("root")).render(
           <Route path="/" element={<App />} />
           <Route path="/boutique" element={<ShopPage />} />
           <Route path="/admin" element={<AdminPage />} />
+          <Route path="/historique" element={<HistoryPage />} />
           <Route path="/login" element={<LoginPage />} />
         </Routes>
       </Router>


### PR DESCRIPTION
## Summary
- log product changes to a new `history` table
- expose `/api/history` and deletion endpoint
- record history when products are added, updated or deleted
- display history in a new History page and allow product removal in admin

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841f307272c83298de5032209ab83a6